### PR TITLE
Fix touch selection coordinates on touch devices

### DIFF
--- a/src/components/SkinAnalyzer.tsx
+++ b/src/components/SkinAnalyzer.tsx
@@ -70,8 +70,8 @@ export default function SkinAnalyzer() {
       if (!overlay) return null;
       const rect = overlay.getBoundingClientRect();
       if (!rect.width || !rect.height) return null;
-      const x = clamp(event.clientX - rect.left, 0, rect.width);
-      const y = clamp(event.clientY - rect.top, 0, rect.height);
+      const x = clamp(event.pageX - (rect.left + window.scrollX), 0, rect.width);
+      const y = clamp(event.pageY - (rect.top + window.scrollY), 0, rect.height);
       return { x, y, rect };
     },
     [clamp]
@@ -219,6 +219,8 @@ export default function SkinAnalyzer() {
                 inset: 0,
                 cursor: "crosshair",
                 borderRadius: 12,
+                touchAction: "none",
+                userSelect: "none",
               }}
             >
               {selection && (


### PR DESCRIPTION
## Summary
- adjust drag position calculation to account for page scroll when selecting on touch devices
- disable touch actions on the overlay so touch drags map directly to the dragged region

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68dc6a7202a0832bbb848f527096fd4f