### PR TITLE
Load head metadata from index.html within App

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,8 @@
     <!-- Favicon（タブ用） -->
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png?v=1" />
     <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192.png?v=1" />
-  </head>
-  <body>
-    <div id="root"></div>
+
     <script type="module" src="/src/main.tsx"></script>
-  </body>
+  </head>
+  <body></body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,41 @@
+import { useEffect } from "react";
 import SkinAnalyzer from "./components/SkinAnalyzer.tsx";
+import headTemplate from "../index.html?raw";
+
+const parser = new DOMParser();
+
+function useHeadTags(html: string) {
+  useEffect(() => {
+    const documentFragment = parser.parseFromString(html, "text/html");
+    const appendedElements: Element[] = [];
+
+    documentFragment.head
+      .querySelectorAll("meta, link, title")
+      .forEach((node) => {
+        const clonedNode = node.cloneNode(true) as Element;
+        const hasSameNode = Array.from(document.head.children).some(
+          (headChild) => headChild.outerHTML === clonedNode.outerHTML,
+        );
+
+        if (!hasSameNode) {
+          document.head.appendChild(clonedNode);
+          appendedElements.push(clonedNode);
+        }
+      });
+
+    return () => {
+      appendedElements.forEach((node) => {
+        if (node.parentNode) {
+          node.parentNode.removeChild(node);
+        }
+      });
+    };
+  }, [html]);
+}
 
 export default function App() {
+  useHeadTags(headTemplate);
+
   return (
     <main
       style={{

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const rootElementId = "root";
+let rootElement = document.getElementById(rootElementId);
+
+if (!rootElement) {
+  rootElement = document.createElement("div");
+  rootElement.id = rootElementId;
+  document.body.appendChild(rootElement);
+}
+
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module "*.html?raw" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- load the metadata and icon links from index.html at runtime so the head tags are applied even when the host page omits them
- dynamically create the root element when it is not present and move the script tag into the head so index.html only holds tag definitions
- add a module declaration for raw HTML imports to satisfy TypeScript

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e797488db4832b9b2f24e311650ad3