### PR TITLE
Render metadata tags via portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,9 +16,8 @@
     <!-- Favicon（タブ用） -->
     <link rel="icon" type="image/png" sizes="32x32" href="/icons/favicon-32.png?v=1" />
     <link rel="icon" type="image/png" sizes="192x192" href="/icons/icon-192.png?v=1" />
-  </head>
-  <body>
-    <div id="root"></div>
+
     <script type="module" src="/src/main.tsx"></script>
-  </body>
+  </head>
+  <body></body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,18 +1,103 @@
+import { createElement, useMemo } from "react";
+import { createPortal } from "react-dom";
 import SkinAnalyzer from "./components/SkinAnalyzer.tsx";
+import headTemplate from "../index.html?raw";
 
 export default function App() {
   return (
-    <main
-      style={{
-        minHeight: "100vh",
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        padding: "48px 16px",
-      }}
-    >
-      <h1 style={{ margin: 0, marginBottom: 60, textAlign: "center" }}>Skin Analyzer</h1>
-      <SkinAnalyzer />
-    </main>
+    <>
+      <HeadTags />
+      <main
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          padding: "48px 16px",
+        }}
+      >
+        <h1 style={{ margin: 0, marginBottom: 60, textAlign: "center" }}>
+          Skin Analyzer
+        </h1>
+        <SkinAnalyzer />
+      </main>
+    </>
+  );
+}
+
+type HeadTagDefinition = {
+  tagName: string;
+  attributes: Array<readonly [string, string]>;
+  textContent: string;
+};
+
+const SUPPORTED_HEAD_TAGS = new Set(["meta", "link", "title"]);
+
+function useHeadTagDefinitions(): HeadTagDefinition[] {
+  return useMemo(() => {
+    if (typeof window === "undefined" || typeof DOMParser === "undefined") {
+      return [];
+    }
+
+    const parser = new DOMParser();
+    const parsedDocument = parser.parseFromString(headTemplate, "text/html");
+    const head = parsedDocument.head;
+
+    if (!head) {
+      return [];
+    }
+
+    return Array.from(head.children).reduce<HeadTagDefinition[]>(
+      (definitions, node) => {
+        const tagName = node.tagName.toLowerCase();
+
+        if (!SUPPORTED_HEAD_TAGS.has(tagName)) {
+          return definitions;
+        }
+
+        const attributes = Array.from(node.attributes).map((attribute) =>
+          [attribute.name, attribute.value] as const,
+        );
+
+        definitions.push({
+          tagName,
+          attributes,
+          textContent: node.textContent ?? "",
+        });
+
+        return definitions;
+      },
+      [],
+    );
+  }, []);
+}
+
+function HeadTags() {
+  const headTagDefinitions = useHeadTagDefinitions();
+
+  if (typeof document === "undefined" || headTagDefinitions.length === 0) {
+    return null;
+  }
+
+  return createPortal(
+    headTagDefinitions.map(({ tagName, attributes, textContent }, index) => {
+      const props = attributes.reduce<Record<string, string>>(
+        (accumulator, [name, value]) => {
+          accumulator[name] = value;
+          return accumulator;
+        },
+        {},
+      );
+
+      return createElement(
+        tagName,
+        {
+          ...props,
+          key: `${tagName}-${index}`,
+        },
+        textContent.trim().length > 0 ? textContent : undefined,
+      );
+    }),
+    document.head,
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,16 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
+const rootElementId = "root";
+let rootElement = document.getElementById(rootElementId);
+
+if (!rootElement) {
+  rootElement = document.createElement("div");
+  rootElement.id = rootElementId;
+  document.body.appendChild(rootElement);
+}
+
+ReactDOM.createRoot(rootElement).render(
   <React.StrictMode>
     <App />
   </React.StrictMode>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="vite/client" />
+
+declare module "*.html?raw" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- render the head metadata parsed from `index.html` directly from `App` so the component return now includes the favicon and related tags
- keep the DOMParser usage browser-only and filter to supported head nodes before creating the portal elements

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e797488db4832b9b2f24e311650ad3